### PR TITLE
Ask For Confirmation for Unsaved Changes

### DIFF
--- a/client/src/views/Day.vue
+++ b/client/src/views/Day.vue
@@ -44,6 +44,7 @@ export default class Day extends Vue {
   public sidebar = SidebarInst;
   public text: string = '';
   public modifiedText : string = '';
+  public unsavedChanges : boolean = false;
   public title: string = '';
   public day!: INote;
   public isLoading: boolean = false;
@@ -61,6 +62,10 @@ export default class Day extends Vue {
       title: this.title
     };
   };
+
+  created() {
+    window.addEventListener('beforeunload', this.unsavedAlert);
+  }
 
   mounted() {
     const date = parse(this.$route.params.id, 'MM-dd-yyyy', new Date());
@@ -99,6 +104,10 @@ export default class Day extends Vue {
       this.text = this.text.replace(original, task);
       this.modifiedText = this.modifiedText.replace(original, task);
     });
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.unsavedAlert);
   }
 
   public async getDayData() {
@@ -147,6 +156,7 @@ export default class Day extends Vue {
       });
     }
 
+    this.unsavedChanges = false;
     this.headerOptions.showDelete = !!this.day.uuid;
   }
 
@@ -199,11 +209,19 @@ export default class Day extends Vue {
     this.modifiedText = data;
 
     if (this.modifiedText !== this.text) {
+      this.unsavedChanges = true;
       this.title = `* ${this.headerOptions.title}`;
       this.headerOptions.saveDisabled = false;
     } else {
       this.title = this.headerOptions.title;
       this.headerOptions.saveDisabled = true;
+    }
+  }
+
+  unsavedAlert(e: Event) {
+    if (this.unsavedChanges) {
+    // Attempt to modify event will trigger Chrome/Firefox alert msg
+    e.returnValue = true;
     }
   }
 }

--- a/client/src/views/Day.vue
+++ b/client/src/views/Day.vue
@@ -11,6 +11,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import { Route } from "vue-router";
 import format from 'date-fns/format';
 import isValid from 'date-fns/isValid';
 import parse from 'date-fns/parse';
@@ -31,7 +32,9 @@ import {newDay} from '../services/consts';
 
 
 Component.registerHooks([
-  'metaInfo'
+  'metaInfo',
+  'beforeRouteUpdate',
+  'beforeRouteLeave'
 ]);
 
 @Component({
@@ -104,6 +107,22 @@ export default class Day extends Vue {
       this.text = this.text.replace(original, task);
       this.modifiedText = this.modifiedText.replace(original, task);
     });
+  }
+
+  beforeRouteUpdate(to: Route, from: Route, next: Function) {
+    if (this.unsavedChanges) {
+      this.unsavedDialog(next);
+    } else {
+      next();
+    }
+  }
+
+  beforeRouteLeave(to: Route, from: Route, next: Function) {
+    if (this.unsavedChanges) {
+      this.unsavedDialog(next);
+    } else {
+      next();
+    }
   }
 
   beforeDestroy() {
@@ -223,6 +242,18 @@ export default class Day extends Vue {
     // Attempt to modify event will trigger Chrome/Firefox alert msg
     e.returnValue = true;
     }
+  }
+
+  async unsavedDialog(next: Function) {
+    this.$buefy.dialog.confirm({
+      title: "Unsaved Content",
+      message: "Are you sure you want to discard the unsaved content?",
+      confirmText: "Discard",
+      type: "is-warning",
+      hasIcon: true,
+      onConfirm: () => next(),
+      onCancel: () => next(false)
+    });
   }
 }
 </script>

--- a/client/src/views/NewNote.vue
+++ b/client/src/views/NewNote.vue
@@ -35,6 +35,7 @@ export default class NewNote extends Vue {
   public sidebar = SidebarInst;
   public text: string = '';
   public modifiedText: string = '';
+  public unsavedChanges : boolean = false;
   public title: string = 'New Note';
   public note!: INote;
   public headerOptions: IHeaderOptions = {
@@ -49,6 +50,10 @@ export default class NewNote extends Vue {
     };
   };
 
+  created() {
+    window.addEventListener('beforeunload', this.unsavedAlert);
+  }
+
   mounted() {
     this.text = newNote;
 
@@ -56,6 +61,10 @@ export default class NewNote extends Vue {
       data: this.text,
       uuid: null
     };
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.unsavedAlert);
   }
 
   public async saveNote() {
@@ -73,6 +82,7 @@ export default class NewNote extends Vue {
       });
     }
 
+    this.unsavedChanges = false;
     this.headerOptions.showDelete = !!this.note.uuid;
   }
 
@@ -82,9 +92,17 @@ export default class NewNote extends Vue {
     if (this.modifiedText !== this.text) {
       this.title = '* New Note';
       this.headerOptions.saveDisabled = false;
+      this.unsavedChanges = true;
     } else {
       this.title = 'New Note';
       this.headerOptions.saveDisabled = true;
+    }
+  }
+
+  unsavedAlert(e: Event) {
+    if (this.unsavedChanges) {
+      // Attempt to modify event will trigger Chrome/Firefox alert msg
+      e.returnValue = true;
     }
   }
 }

--- a/client/src/views/Note.vue
+++ b/client/src/views/Note.vue
@@ -42,6 +42,7 @@ export default class Note extends Vue {
   public sidebar = SidebarInst;
   public text: string = '';
   public modifiedText : string = '';
+  public unsavedChanges : boolean = false;
   public title: string = 'Note';
   public note!: INote;
   public isLoading: boolean = false;
@@ -59,6 +60,10 @@ export default class Note extends Vue {
     };
   };
 
+  created() {
+    window.addEventListener('beforeunload', this.unsavedAlert);
+  }
+
   async mounted() {
     this.isLoading = true;
 
@@ -73,7 +78,7 @@ export default class Note extends Vue {
     }
 
     this.isLoading = false;
-    
+
     this.$root.$on('taskUpdated', (data: any) => {
       const {note_id, task, completed} = data;
 
@@ -94,6 +99,10 @@ export default class Note extends Vue {
     });
   }
 
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.unsavedAlert);
+  }
+
   public async saveNote() {
     const updatedNote = Object.assign(this.note, {data: this.modifiedText});
     try {
@@ -112,6 +121,7 @@ export default class Note extends Vue {
         type: 'is-danger'
       });
     }
+    this.unsavedChanges = false;
   }
 
   public async deleteNote() {
@@ -150,11 +160,19 @@ export default class Note extends Vue {
     this.modifiedText = data;
 
     if (this.modifiedText !== this.text) {
+      this.unsavedChanges = true;
       this.title = `* ${this.note.title}`;
       this.headerOptions.saveDisabled = false;
     } else {
       this.title = this.note.title || '';
       this.headerOptions.saveDisabled = true;
+    }
+  }
+
+  unsavedAlert(e: Event) {
+    if (this.unsavedChanges) {
+      // Attempt to modify event will trigger Chrome/Firefox alert msg
+      e.returnValue = true;
     }
   }
 }

--- a/client/src/views/Note.vue
+++ b/client/src/views/Note.vue
@@ -11,6 +11,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import { Route } from "vue-router";
 import format from 'date-fns/format';
 import isValid from 'date-fns/isValid';
 import parse from 'date-fns/parse';
@@ -29,7 +30,9 @@ import {IHeaderOptions} from '../interfaces';
 
 
 Component.registerHooks([
-  'metaInfo'
+  'metaInfo',
+  'beforeRouteUpdate',
+  'beforeRouteLeave'
 ]);
 
 @Component({
@@ -97,6 +100,22 @@ export default class Note extends Vue {
       this.text = this.text.replace(original, task);
       this.modifiedText = this.modifiedText.replace(original, task);
     });
+  }
+
+  beforeRouteUpdate(to: Route, from: Route, next: Function) {
+    if (this.unsavedChanges) {
+      this.unsavedDialog(next);
+    } else {
+      next();
+    }
+  }
+
+  beforeRouteLeave(to: Route, from: Route, next: Function) {
+    if (this.unsavedChanges) {
+      this.unsavedDialog(next);
+    } else {
+      next();
+    }
   }
 
   beforeDestroy() {
@@ -174,6 +193,18 @@ export default class Note extends Vue {
       // Attempt to modify event will trigger Chrome/Firefox alert msg
       e.returnValue = true;
     }
+  }
+
+  async unsavedDialog(next: Function) {
+    this.$buefy.dialog.confirm({
+      title: "Unsaved Content",
+      message: "Are you sure you want to discard the unsaved content?",
+      confirmText: "Discard",
+      type: "is-warning",
+      hasIcon: true,
+      onConfirm: () => next(),
+      onCancel: () => next(false)
+    });
   }
 }
 </script>


### PR DESCRIPTION
This PR implements the feature mentioned in #26.

Adds confirmation for discard unsaved notes/daily notes when users attempt to:
- Close the tab
- Switch to other notes/daily notes (in different routes).
