### PR TITLE
fix: upgrade js-yaml to 4.1.1+ for CVE-2024-4068

### DIFF
--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -2874,9 +2874,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -10,6 +10,7 @@
     "electron-builder": "^24.9.1"
   },
   "overrides": {
-    "glob": "^10.5.0"
+    "glob": "^10.5.0",
+    "js-yaml": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm override for js-yaml to force version ^4.1.1
- Fixes prototype pollution vulnerability in js-yaml merge (<<) functionality
- Resolves Dependabot alert #172

## Test plan
- [x] `npm install` succeeds
- [x] `npm ls js-yaml` shows version 4.1.1+