### PR TITLE
ci: add GitHub release on merge to master

### DIFF
--- a/.github/workflows/push-docker-hub.yml
+++ b/.github/workflows/push-docker-hub.yml
@@ -125,6 +125,22 @@ jobs:
           echo "version=skipped" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Create GitHub Release
+        if: steps.tag.outputs.version != 'skipped'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          name: Release ${{ steps.tag.outputs.version }}
+          body: |
+            ## What's Changed
+
+            Docker image available at:
+            - `xhenxhe/dailynotes:${{ steps.tag.outputs.version }}`
+            - `xhenxhe/dailynotes:latest`
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # DailyNotes Architecture Guide
 
+## Important Rules
+
+- **Never commit unless explicitly told to.** Wait for the user to ask you to commit changes.
+
 ## Project Overview
 
 DailyNotes is a self-hosted daily task and note-taking application that combines the experience of a physical planner with modern web technology. It supports markdown with GitHub Flavored Markdown (GFM) task lists, making it ideal for daily journaling, task tracking, and note management.


### PR DESCRIPTION
## Summary

- Add automatic GitHub Release creation when code is merged to master
- Release includes auto-generated changelog from PRs/commits
- Shows Docker image availability in release body
- Only creates release if git tag creation succeeds

## Test plan

- [ ] Merge to master and verify GitHub Release is created
- [ ] Verify release includes auto-generated notes
- [ ] Verify Docker image tags are listed in release body