### PR TITLE
feat: add RTL language support

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -225,20 +225,6 @@ code, pre {
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
 }
 
-/* ========================================
-   Direction CSS (RTL/LTR Support)
-   ======================================== */
-
-/* LTR is default - no special styling needed */
-:root, .dir-ltr {
-  --text-direction: ltr;
-}
-
-/* RTL mode */
-.dir-rtl {
-  --text-direction: rtl;
-}
-
 .fade-enter-active, .fade-leave-active {
   transition: opacity .5s;
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -225,6 +225,20 @@ code, pre {
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
 }
 
+/* ========================================
+   Direction CSS (RTL/LTR Support)
+   ======================================== */
+
+/* LTR is default - no special styling needed */
+:root, .dir-ltr {
+  --text-direction: ltr;
+}
+
+/* RTL mode */
+.dir-rtl {
+  --text-direction: rtl;
+}
+
 .fade-enter-active, .fade-leave-active {
   transition: opacity .5s;
 }

--- a/client/src/components/Editor.vue
+++ b/client/src/components/Editor.vue
@@ -35,6 +35,7 @@ import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { IGlobal } from '../interfaces';
 
 import { newDay, newNote } from '../services/consts';
+import directionService from '../services/direction';
 import eventHub from '../services/eventHub';
 import { SharedBuefy } from '../services/sharedBuefy';
 import themeService from '../services/theme';
@@ -813,6 +814,10 @@ const getExtensions = (): Extension[] => {
         const newValue = update.state.doc.toString();
         generateTaskList(newValue);
         throttledEmit(newValue);
+        // Update auto-direction if in auto mode
+        if (directionService.preference === 'auto') {
+          debouncedDirectionUpdate(newValue);
+        }
       }
     }),
     EditorView.domEventHandlers({
@@ -859,6 +864,15 @@ const throttledEmit = _.throttle(
   { trailing: true, leading: false }
 );
 
+// Debounced direction update for auto-detection
+const debouncedDirectionUpdate = _.debounce(
+  (value: string) => {
+    directionService.updateAutoDirection(value);
+  },
+  300,
+  { trailing: true, leading: false }
+);
+
 onMounted(() => {
   if (!editorContainer.value) return;
 
@@ -873,6 +887,10 @@ onMounted(() => {
   handleValueUpdate(true);
   // Generate task list on initial mount
   generateTaskList(props.value || '');
+  // Trigger auto-direction on initial content
+  if (directionService.preference === 'auto') {
+    directionService.updateAutoDirection(props.value || '');
+  }
   eventHub.on('focusEditor', focus);
 });
 
@@ -977,7 +995,7 @@ defineExpose({
   }
 
   .editor :deep(.cm-gutters) {
-    padding-left: 4px;
+    padding-inline-start: 4px;
   }
 }
 </style>

--- a/client/src/components/Editor.vue
+++ b/client/src/components/Editor.vue
@@ -869,7 +869,7 @@ const debouncedDirectionUpdate = _.debounce(
   (value: string) => {
     directionService.updateAutoDirection(value);
   },
-  300,
+  500,
   { trailing: true, leading: false }
 );
 

--- a/client/src/components/Header.vue
+++ b/client/src/components/Header.vue
@@ -409,15 +409,14 @@ const logout = () => {
 }
 
 .dropdown-text {
-  margin-left: 8px;
-  margin-right: 12px;
+  margin-inline-start: 8px;
+  margin-inline-end: 12px;
 }
 
 .dropdown-shortcut {
   opacity: 0.6;
   font-size: 0.85em;
-  margin-left: auto;
-  float: right;
+  margin-inline-start: auto;
 }
 
 /* Mobile-only items in dropdown - hidden by default */
@@ -456,8 +455,8 @@ const logout = () => {
   }
 
   .header-title {
-    margin-left: 0.5em;
-    margin-right: 0.5em;
+    margin-inline-start: 0.5em;
+    margin-inline-end: 0.5em;
   }
 
   .header-left,

--- a/client/src/components/MarkdownPreview.vue
+++ b/client/src/components/MarkdownPreview.vue
@@ -373,7 +373,7 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
   color: var(--syntax-keyword);
   font-weight: 600;
   min-width: 100px;
-  margin-right: 12px;
+  margin-inline-end: 12px;
   font-size: 0.9em;
 }
 
@@ -460,14 +460,14 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
 
 /* Lists */
 .preview-content :deep(ul) {
-  padding-left: 2em;
+  padding-inline-start: 2em;
   margin-top: 0;
   margin-bottom: 16px;
   list-style-type: disc;
 }
 
 .preview-content :deep(ol) {
-  padding-left: 2em;
+  padding-inline-start: 2em;
   margin-top: 0;
   margin-bottom: 16px;
   list-style-type: decimal;
@@ -490,11 +490,11 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
 /* Task lists */
 .preview-content :deep(.task-list-item) {
   list-style-type: none;
-  margin-left: -1.5em;
+  margin-inline-start: -1.5em;
 }
 
 .preview-content :deep(.task-list-item input[type="checkbox"]) {
-  margin-right: 0.5em;
+  margin-inline-end: 0.5em;
   vertical-align: middle;
   cursor: pointer;
   accent-color: var(--accent-primary);
@@ -531,9 +531,9 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
 
 /* Blockquotes */
 .preview-content :deep(blockquote) {
-  border-left: 4px solid var(--text-link);
-  padding-left: 16px;
-  margin-left: 0;
+  border-inline-start: 4px solid var(--text-link);
+  padding-inline-start: 16px;
+  margin-inline-start: 0;
   margin-bottom: 16px;
   color: var(--text-muted);
 }
@@ -549,7 +549,7 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
 .preview-content :deep(table td) {
   border: 1px solid var(--border-color);
   padding: 8px 12px;
-  text-align: left;
+  text-align: start;
 }
 
 .preview-content :deep(table th) {
@@ -614,7 +614,7 @@ const toggleCheckboxInMarkdown = (checkboxInfo: CheckboxInfo): string => {
 
   .frontmatter-key {
     min-width: 80px;
-    margin-right: 8px;
+    margin-inline-end: 8px;
   }
 
   .preview-content :deep(pre) {

--- a/client/src/components/NestedTags.vue
+++ b/client/src/components/NestedTags.vue
@@ -169,7 +169,7 @@ function onChildExpandedChange(childExpanded: string[]) {
 }
 
 .children-inline {
-  padding-left: 20px;
+  padding-inline-start: 20px;
 }
 
 /* Nested level: inline layout */
@@ -188,7 +188,7 @@ function onChildExpandedChange(childExpanded: string[]) {
 
 .sub-children {
   display: inline-flex;
-  margin-left: 0.25em;
+  margin-inline-start: 0.25em;
 }
 
 /* Toggle icons */
@@ -201,7 +201,7 @@ function onChildExpandedChange(childExpanded: string[]) {
   cursor: pointer;
   color: var(--text-muted);
   font-size: 0.7em;
-  margin-right: 4px;
+  margin-inline-end: 4px;
   flex-shrink: 0;
 }
 
@@ -216,7 +216,7 @@ function onChildExpandedChange(childExpanded: string[]) {
   cursor: pointer;
   color: var(--text-muted);
   font-size: 0.7em;
-  margin-right: 2px;
+  margin-inline-end: 2px;
   width: 12px;
 }
 

--- a/client/src/components/Settings.vue
+++ b/client/src/components/Settings.vue
@@ -36,6 +36,23 @@
           </div>
 
           <div class="settings-card">
+            <p class="section-title">Text Direction</p>
+            <p class="section-hint">Choose your preferred text direction for RTL languages.</p>
+            <div class="direction-selector">
+              <button
+                v-for="option in directionOptions"
+                :key="option.value"
+                class="direction-option"
+                :class="{ active: localDirection === option.value }"
+                @click="localDirection = option.value as DirectionPreference; onDirectionChange(option.value as DirectionPreference)"
+              >
+                <i :class="option.icon"></i>
+                <span>{{ option.label }}</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="settings-card">
             <p class="section-title">Calendar sharing</p>
             <p class="section-hint">Expose daily notes as all-day events via a private ICS link.</p>
             <div class="setting-row">
@@ -193,6 +210,7 @@ import { CalendarService } from '../services/calendars';
 import { Requests } from '../services/requests';
 import type { BuefyInstance } from '../services/sharedBuefy';
 import sidebar from '../services/sidebar';
+import directionService, { type DirectionPreference } from '../services/direction';
 import themeService, { type ThemePreference } from '../services/theme';
 
 const emit = defineEmits<{
@@ -205,6 +223,7 @@ const buefy = (instance?.appContext.config.globalProperties as { $buefy?: BuefyI
 const localAutoSave = ref(false);
 const localVimMode = ref(false);
 const localTheme = ref<ThemePreference>('system');
+const localDirection = ref<DirectionPreference>('ltr');
 const localKanbanEnabled = ref(false);
 const localKanbanColumns = ref<string[]>(['todo', 'done']);
 
@@ -212,6 +231,12 @@ const themeOptions = [
   { value: 'light', label: 'Light', icon: 'fas fa-sun' },
   { value: 'dark', label: 'Dark', icon: 'fas fa-moon' },
   { value: 'system', label: 'System', icon: 'fas fa-laptop' },
+];
+
+const directionOptions = [
+  { value: 'ltr', label: 'LTR', icon: 'fas fa-align-left' },
+  { value: 'rtl', label: 'RTL', icon: 'fas fa-align-right' },
+  { value: 'auto', label: 'Auto', icon: 'fas fa-magic' },
 ];
 const calendarEnabled = ref(false);
 const calendarUrl = ref('');
@@ -229,6 +254,7 @@ onMounted(() => {
   localAutoSave.value = sidebar.autoSave;
   localVimMode.value = sidebar.vimMode;
   localTheme.value = themeService.preference;
+  localDirection.value = directionService.preference;
   localKanbanEnabled.value = sidebar.kanbanEnabled;
   localKanbanColumns.value = [...sidebar.kanbanColumns];
 
@@ -271,6 +297,22 @@ const onThemeChange = (value: ThemePreference) => {
 
   buefy?.toast.open({
     message: `${labels[value]} activated`,
+    type: 'is-success',
+    duration: 2000,
+  });
+};
+
+const onDirectionChange = (value: DirectionPreference) => {
+  directionService.preference = value;
+
+  const labels: Record<DirectionPreference, string> = {
+    ltr: 'Left-to-Right',
+    rtl: 'Right-to-Left',
+    auto: 'Auto-detect',
+  };
+
+  buefy?.toast.open({
+    message: `${labels[value]} direction activated`,
     type: 'is-success',
     duration: 2000,
   });
@@ -589,6 +631,47 @@ const close = () => {
 }
 
 .theme-option span {
+  font-size: 0.9em;
+  font-weight: 500;
+}
+
+/* Direction selector - same styling as theme selector */
+.direction-selector {
+  display: flex;
+  gap: 8px;
+}
+
+.direction-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 12px;
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.direction-option:hover {
+  border-color: var(--border-color-light);
+  background: var(--main-bg-lighter);
+}
+
+.direction-option.active {
+  border-color: var(--accent-primary);
+  background: var(--main-bg-lighter);
+  color: var(--text-primary);
+}
+
+.direction-option i {
+  font-size: 1.5em;
+}
+
+.direction-option span {
   font-size: 0.9em;
   font-weight: 500;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -5,6 +5,9 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 
+// Initialize direction service (self-initializes on import)
+import './services/direction';
+
 const app = createApp(App);
 const head = createHead();
 

--- a/client/src/services/direction.ts
+++ b/client/src/services/direction.ts
@@ -1,0 +1,161 @@
+import { reactive, watch } from 'vue';
+import { getItemOrDefault, setItem } from './localstorage';
+
+export type DirectionPreference = 'ltr' | 'rtl' | 'auto';
+export type ResolvedDirection = 'ltr' | 'rtl';
+
+const DIRECTION_STORAGE_KEY = 'dn-direction-preference';
+
+interface DirectionState {
+  preference: DirectionPreference;
+  resolved: ResolvedDirection;
+  autoDetectedDirection: ResolvedDirection;
+}
+
+class DirectionService {
+  private state: DirectionState;
+
+  constructor() {
+    const stored = getItemOrDefault<DirectionPreference>(DIRECTION_STORAGE_KEY, 'ltr');
+    const preference = stored || 'ltr';
+
+    this.state = reactive({
+      preference,
+      resolved: preference === 'auto' ? 'ltr' : (preference as ResolvedDirection),
+      autoDetectedDirection: 'ltr',
+    });
+
+    this.applyDirection();
+
+    watch(
+      () => this.state.preference,
+      (newPref) => {
+        this.state.resolved = this.resolveDirection(newPref);
+        setItem(DIRECTION_STORAGE_KEY, newPref);
+        this.applyDirection();
+      }
+    );
+  }
+
+  /**
+   * Get the current direction preference (ltr/rtl/auto)
+   */
+  get preference(): DirectionPreference {
+    return this.state.preference;
+  }
+
+  /**
+   * Set the direction preference
+   */
+  set preference(value: DirectionPreference) {
+    this.state.preference = value;
+  }
+
+  /**
+   * Get the resolved direction (ltr or rtl)
+   */
+  get resolved(): ResolvedDirection {
+    return this.state.resolved;
+  }
+
+  /**
+   * Check if the current resolved direction is RTL
+   */
+  get isRTL(): boolean {
+    return this.state.resolved === 'rtl';
+  }
+
+  /**
+   * Check if the current resolved direction is LTR
+   */
+  get isLTR(): boolean {
+    return this.state.resolved === 'ltr';
+  }
+
+  /**
+   * Resolve the direction preference to actual ltr/rtl
+   */
+  private resolveDirection(preference: DirectionPreference): ResolvedDirection {
+    if (preference === 'auto') {
+      return this.state.autoDetectedDirection;
+    }
+    return preference;
+  }
+
+  /**
+   * Update auto-detected direction based on content.
+   * Call this when editor content changes.
+   */
+  public updateAutoDirection(content: string): void {
+    const detected = this.detectDirection(content);
+    this.state.autoDetectedDirection = detected;
+
+    if (this.state.preference === 'auto') {
+      this.state.resolved = detected;
+      this.applyDirection();
+    }
+  }
+
+  /**
+   * Detect direction from text content using RTL Unicode ranges
+   */
+  private detectDirection(text: string): ResolvedDirection {
+    // Strip frontmatter (between --- delimiters)
+    const contentWithoutFrontmatter = this.stripFrontmatter(text);
+
+    // Get first 200 characters of actual content
+    const sample = contentWithoutFrontmatter.slice(0, 200);
+
+    // RTL Unicode ranges:
+    // - Arabic: \u0600-\u06FF, \u0750-\u077F, \u08A0-\u08FF
+    // - Hebrew: \u0590-\u05FF
+    // - Persian/Farsi Extended: \uFB50-\uFDFF, \uFE70-\uFEFF
+    // - Syriac: \u0700-\u074F
+    const rtlPattern =
+      /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\u0590-\u05FF\uFB50-\uFDFF\uFE70-\uFEFF\u0700-\u074F]/g;
+    const ltrPattern = /[A-Za-z\u00C0-\u024F]/g; // Latin characters
+
+    const rtlMatches = (sample.match(rtlPattern) || []).length;
+    const ltrMatches = (sample.match(ltrPattern) || []).length;
+
+    // Return RTL if RTL characters are majority
+    if (rtlMatches > 0 && rtlMatches >= ltrMatches) {
+      return 'rtl';
+    }
+    return 'ltr';
+  }
+
+  /**
+   * Strip YAML frontmatter from text
+   */
+  private stripFrontmatter(text: string): string {
+    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n/;
+    return text.replace(frontmatterRegex, '');
+  }
+
+  /**
+   * Apply the current direction to the document
+   */
+  private applyDirection(): void {
+    if (typeof document === 'undefined') return;
+
+    const root = document.documentElement;
+    const body = document.body;
+
+    // Remove existing direction classes
+    root.classList.remove('dir-ltr', 'dir-rtl');
+    body.classList.remove('dir-ltr', 'dir-rtl');
+
+    // Add current direction class
+    const dirClass = `dir-${this.state.resolved}`;
+    root.classList.add(dirClass);
+    body.classList.add(dirClass);
+
+    // Set dir attribute for native browser RTL support
+    root.setAttribute('dir', this.state.resolved);
+  }
+}
+
+// Export singleton instance
+const directionService = new DirectionService();
+export default directionService;

--- a/client/src/services/direction.ts
+++ b/client/src/services/direction.ts
@@ -88,11 +88,14 @@ class DirectionService {
    */
   public updateAutoDirection(content: string): void {
     const detected = this.detectDirection(content);
-    this.state.autoDetectedDirection = detected;
 
-    if (this.state.preference === 'auto') {
-      this.state.resolved = detected;
-      this.applyDirection();
+    if (this.state.autoDetectedDirection !== detected) {
+      this.state.autoDetectedDirection = detected;
+
+      if (this.state.preference === 'auto') {
+        this.state.resolved = detected;
+        this.applyDirection();
+      }
     }
   }
 
@@ -129,7 +132,7 @@ class DirectionService {
    * Strip YAML frontmatter from text
    */
   private stripFrontmatter(text: string): string {
-    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n/;
+    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n?/;
     return text.replace(frontmatterRegex, '');
   }
 

--- a/client/src/views/Day.vue
+++ b/client/src/views/Day.vue
@@ -600,7 +600,7 @@ onBeforeUnmount(() => {
 }
 
 .editor-split {
-  border-right: 1px solid #404854;
+  border-inline-end: 1px solid #404854;
 }
 
 /* Full-width preview when editor is hidden (replace mode) */
@@ -636,8 +636,8 @@ onBeforeUnmount(() => {
   }
 
   .editor-split {
-    border-right: none;
-    border-bottom: 1px solid #404854;
+    border-inline-end: none;
+    border-block-end: 1px solid #404854;
   }
 
   :deep(.external-events) {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -122,8 +122,7 @@ onBeforeUnmount(() => {
 }
 
 .center-columns {
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
 }
 
 .sidebar {

--- a/client/src/views/Note.vue
+++ b/client/src/views/Note.vue
@@ -502,7 +502,7 @@ onBeforeUnmount(() => {
 }
 
 .editor-split {
-  border-right: 1px solid #404854;
+  border-inline-end: 1px solid #404854;
 }
 
 /* Full-width preview when editor is hidden (replace mode) */
@@ -533,8 +533,8 @@ onBeforeUnmount(() => {
   }
 
   .editor-split {
-    border-right: none;
-    border-bottom: 1px solid #404854;
+    border-inline-end: none;
+    border-block-end: 1px solid #404854;
   }
 }
 </style>

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -404,8 +404,8 @@ onMounted(() => {
 .autocomplete-dropdown {
   position: absolute;
   top: 100%;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   background: var(--dropdown-bg);
   border: 1px solid var(--border-color);
   border-radius: 4px;
@@ -475,7 +475,7 @@ onMounted(() => {
 }
 
 .syntax-help table td:first-child {
-  padding-right: 12px;
+  padding-inline-end: 12px;
 }
 
 .syntax-help code {


### PR DESCRIPTION
## Summary
- Add right-to-left (RTL) language support with three modes: LTR, RTL, and Auto-detect
- Create direction service following the theme service pattern with localStorage persistence
- Add direction selector in Settings modal with matching UI style
- Convert physical CSS properties to logical properties (margin-inline-start/end, etc.)
- Integrate auto-detection with editor to detect RTL content (Arabic, Hebrew, Persian, Syriac)

## Test plan
- [ ] Verify LTR mode works as default
- [ ] Test RTL mode flips UI layout correctly
- [ ] Test Auto mode detects Arabic/Hebrew text and switches direction
- [ ] Verify setting persists across page reloads
- [ ] Test on mobile viewport