### PR TITLE
feat: add password recovery and magic link sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,98 @@ Joe had a vision for what DailyNotes could become before calling it a 1.0 releas
 - **Multi-user Support** — Multiple users with separate, encrypted data
 - **No Vendor Lock-in** — Export all your notes as markdown files anytime
 
+### Account Security
+
+- **[Password Recovery](#password-recovery--magic-link)** — Reset your password via email if forgotten
+- **[Magic Link Sign-in](#password-recovery--magic-link)** — Sign in with a secure email link instead of a password
+- **Email Management** — Add or update your email in Settings to enable these features
+
+## Password Recovery & Magic Link
+
+DailyNotes supports password recovery and passwordless sign-in via email. These features require SMTP configuration (see [Environment Variables](#environment-variables)).
+
+### Setting Up Your Email
+
+1. Click the **menu icon** (⋮) in the header
+2. Select **Settings**
+3. In the **Account** section, enter your email address
+4. Click **Add Email**
+
+Once configured, you can use password recovery and magic link sign-in.
+
+### Forgot Password
+
+If you forget your password:
+
+1. Go to the login page
+2. Click **Forgot password?**
+3. Enter your email address
+4. Check your email for a reset link (valid for 1 hour)
+5. Click the link and enter your new password
+
+### Magic Link Sign-in
+
+Sign in without entering your password:
+
+1. Go to the login page
+2. Click **Sign in with email**
+3. Enter your email address
+4. Check your email for a sign-in link (valid for 15 minutes)
+5. Click the link to automatically sign in
+
+### Security Features
+
+| Feature                      | Description                               |
+| ---------------------------- | ----------------------------------------- |
+| Secure tokens                | Cryptographically random, SHA-256 hashed  |
+| Rate limiting                | 3 requests per email per hour             |
+| Short expiration             | Reset: 1 hour, Magic link: 15 minutes     |
+| Single-use tokens            | Each token can only be used once          |
+| Email enumeration prevention | Same response whether email exists or not |
+| Encrypted email storage      | Email addresses encrypted at rest (AES)   |
+
+### SMTP Configuration Examples
+
+**Gmail (with App Password):**
+
+```yaml
+SMTP_HOST: smtp.gmail.com
+SMTP_PORT: 587
+SMTP_USER: your-email@gmail.com
+SMTP_PASSWORD: your-app-password # Generate at myaccount.google.com/apppasswords
+SMTP_FROM_NAME: DailyNotes
+APP_URL: https://your-dailynotes-instance.com
+```
+
+**Mailgun:**
+
+```yaml
+SMTP_HOST: smtp.mailgun.org
+SMTP_PORT: 587
+SMTP_USER: postmaster@your-domain.mailgun.org
+SMTP_PASSWORD: your-mailgun-password
+SMTP_FROM_EMAIL: noreply@your-domain.com
+APP_URL: https://your-dailynotes-instance.com
+```
+
+**Amazon SES:**
+
+```yaml
+SMTP_HOST: email-smtp.us-east-1.amazonaws.com
+SMTP_PORT: 587
+SMTP_USER: your-ses-smtp-username
+SMTP_PASSWORD: your-ses-smtp-password
+SMTP_FROM_EMAIL: noreply@your-verified-domain.com
+APP_URL: https://your-dailynotes-instance.com
+```
+
+**Important Notes:**
+
+- Gmail requires an [App Password](https://myaccount.google.com/apppasswords), not your regular password
+- The `APP_URL` must match the URL users access DailyNotes from (for email links to work)
+- If SMTP is not configured, password recovery and magic link features are automatically disabled
+- Users can still sign in with username/password even without email configured
+
 ## Themes
 
 DailyNotes supports **Light**, **Dark**, and **System** themes to match your preferred working environment.
@@ -365,6 +457,14 @@ The recommended way of running is to pull the image from [Docker Hub](https://hu
 | PUID                 | User ID (for folder permissions)                                                                                                     | None                                              |
 | PGID                 | Group ID (for folder permissions)                                                                                                    | None                                              |
 | DEFAULT_TIMEZONE     | Optional TZ name (e.g., `America/Denver`) for external ICS events; falls back to server local time                                   | None                                              |
+| SMTP_HOST            | SMTP server hostname for sending emails (password reset, magic links)                                                                | None (email features disabled)                    |
+| SMTP_PORT            | SMTP server port                                                                                                                     | 587                                               |
+| SMTP_USER            | SMTP username/email for authentication                                                                                               | None                                              |
+| SMTP_PASSWORD        | SMTP password or app-specific password                                                                                               | None                                              |
+| SMTP_USE_TLS         | Use TLS for SMTP connection (`true` or `false`)                                                                                      | true                                              |
+| SMTP_FROM_EMAIL      | From address for sent emails                                                                                                         | SMTP_USER value                                   |
+| SMTP_FROM_NAME       | Display name for sent emails                                                                                                         | DailyNotes                                        |
+| APP_URL              | Public URL of your DailyNotes instance (used in email links)                                                                         | http://localhost:8000                             |
 
 #### Volumes
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -125,6 +125,11 @@ class JWTManager:
 
 jwt_manager = JWTManager(app)
 
+# Import and initialize email service
+from app.email_service import email_service
+
+email_service.init_app(app)
+
 
 def create_access_token(identity):
     """Create a JWT access token"""

--- a/app/auth_tokens.py
+++ b/app/auth_tokens.py
@@ -1,0 +1,249 @@
+"""
+Secure token generation and validation for password reset and magic links.
+
+Security measures:
+- Tokens are cryptographically random (32 bytes, URL-safe)
+- Tokens are hashed with SHA-256 before storage
+- Rate limiting prevents brute force and email spam
+- Short expiration times limit exposure window
+"""
+
+import secrets
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+import logging
+
+from app import db
+from app.models import User, AuthToken, RateLimit
+
+logger = logging.getLogger(__name__)
+
+# Token expiration times
+PASSWORD_RESET_EXPIRY = timedelta(hours=1)
+MAGIC_LINK_EXPIRY = timedelta(minutes=15)
+
+# Rate limiting: 3 requests per email per hour
+RATE_LIMIT_WINDOW = timedelta(hours=1)
+RATE_LIMIT_MAX_REQUESTS = 3
+
+
+def generate_token() -> str:
+    """
+    Generate a cryptographically secure random token.
+
+    Returns a 43-character URL-safe base64 string (32 bytes of entropy).
+    """
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """
+    Hash a token using SHA-256 for secure storage.
+
+    The hash is stored in the database, not the raw token.
+    This means even if the database is compromised, tokens cannot be recovered.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def hash_email_for_rate_limit(email: str) -> str:
+    """
+    Hash email for rate limiting.
+
+    Uses SHA-256 to create a consistent identifier without storing PII.
+    """
+    return hashlib.sha256(email.lower().strip().encode()).hexdigest()
+
+
+def check_rate_limit(email: str, action_type: str) -> bool:
+    """
+    Check if action is rate limited for this email.
+
+    Args:
+        email: User's email address
+        action_type: Type of action ('password_reset' or 'magic_link')
+
+    Returns:
+        True if request is allowed, False if rate limited
+    """
+    identifier = hash_email_for_rate_limit(email)
+    cutoff = datetime.now(timezone.utc) - RATE_LIMIT_WINDOW
+
+    # Count recent requests
+    count = RateLimit.query.filter(
+        RateLimit.identifier == identifier,
+        RateLimit.action_type == action_type,
+        RateLimit.timestamp > cutoff,
+    ).count()
+
+    return count < RATE_LIMIT_MAX_REQUESTS
+
+
+def record_rate_limit(email: str, action_type: str):
+    """
+    Record a rate-limited action.
+
+    Args:
+        email: User's email address
+        action_type: Type of action ('password_reset' or 'magic_link')
+    """
+    identifier = hash_email_for_rate_limit(email)
+    rate_limit = RateLimit(identifier=identifier, action_type=action_type)
+    db.session.add(rate_limit)
+    db.session.commit()
+
+
+def create_auth_token(user: User, token_type: str) -> str:
+    """
+    Create a new auth token for a user.
+
+    Invalidates any existing unused tokens of the same type for security.
+
+    Args:
+        user: User to create token for
+        token_type: Type of token ('password_reset' or 'magic_link')
+
+    Returns:
+        The raw token (for sending in email). This is the only time
+        the raw token is available - it's not stored in the database.
+    """
+    # Invalidate any existing unused tokens of this type for this user
+    AuthToken.query.filter(
+        AuthToken.user_id == user.uuid,
+        AuthToken.token_type == token_type,
+        AuthToken.used_at.is_(None),
+    ).delete()
+    db.session.commit()
+
+    # Generate new token
+    raw_token = generate_token()
+    token_hash = hash_token(raw_token)
+
+    # Set expiry based on token type
+    if token_type == "password_reset":
+        expiry = datetime.now(timezone.utc) + PASSWORD_RESET_EXPIRY
+    else:  # magic_link
+        expiry = datetime.now(timezone.utc) + MAGIC_LINK_EXPIRY
+
+    auth_token = AuthToken(
+        user_id=user.uuid,
+        token_hash=token_hash,
+        token_type=token_type,
+        expires_at=expiry,
+    )
+    db.session.add(auth_token)
+    db.session.commit()
+
+    logger.info(f"Created {token_type} token for user {user.username}")
+    return raw_token
+
+
+def validate_token(raw_token: str, token_type: str) -> Optional[User]:
+    """
+    Validate a token and return the associated user if valid.
+
+    Uses hash comparison which provides constant-time behavior through
+    the database query (preventing timing attacks).
+
+    Args:
+        raw_token: The raw token from the URL
+        token_type: Expected token type ('password_reset' or 'magic_link')
+
+    Returns:
+        User if token is valid, None otherwise
+    """
+    token_hash = hash_token(raw_token)
+
+    auth_token = AuthToken.query.filter(
+        AuthToken.token_hash == token_hash,
+        AuthToken.token_type == token_type,
+        AuthToken.used_at.is_(None),
+        AuthToken.expires_at > datetime.now(timezone.utc),
+    ).first()
+
+    if not auth_token:
+        logger.warning(f"Invalid or expired {token_type} token attempted")
+        return None
+
+    return User.query.get(auth_token.user_id)
+
+
+def invalidate_token(raw_token: str) -> bool:
+    """
+    Mark a token as used.
+
+    Args:
+        raw_token: The raw token to invalidate
+
+    Returns:
+        True if token was found and invalidated, False otherwise
+    """
+    token_hash = hash_token(raw_token)
+
+    auth_token = AuthToken.query.filter(AuthToken.token_hash == token_hash).first()
+
+    if auth_token:
+        auth_token.used_at = datetime.now(timezone.utc)
+        db.session.add(auth_token)
+        db.session.commit()
+        logger.info(f"Invalidated {auth_token.token_type} token")
+        return True
+
+    return False
+
+
+def cleanup_expired_tokens():
+    """
+    Remove expired tokens and old rate limit records.
+
+    Can be called periodically (e.g., daily) to keep the database clean.
+    """
+    cutoff = datetime.now(timezone.utc)
+
+    # Delete expired tokens
+    expired_count = AuthToken.query.filter(AuthToken.expires_at < cutoff).delete()
+
+    # Delete old used tokens (keep for a day for audit)
+    used_cutoff = cutoff - timedelta(days=1)
+    used_count = AuthToken.query.filter(
+        AuthToken.used_at.isnot(None), AuthToken.used_at < used_cutoff
+    ).delete()
+
+    # Clean up old rate limit records
+    rate_cutoff = cutoff - RATE_LIMIT_WINDOW
+    rate_count = RateLimit.query.filter(RateLimit.timestamp < rate_cutoff).delete()
+
+    db.session.commit()
+
+    logger.info(
+        f"Cleanup: removed {expired_count} expired tokens, "
+        f"{used_count} used tokens, {rate_count} rate limit records"
+    )
+
+
+def get_user_by_email(email: str) -> Optional[User]:
+    """
+    Find a user by their email address.
+
+    Email lookup is case-insensitive.
+
+    Args:
+        email: Email address to search for
+
+    Returns:
+        User if found, None otherwise
+    """
+    if not email:
+        return None
+
+    email_normalized = email.lower().strip()
+
+    # We need to check all users since email is encrypted
+    # This is not ideal for large user bases, but acceptable for self-hosted
+    users = User.query.all()
+    for user in users:
+        if user.email and user.email.lower() == email_normalized:
+            return user
+
+    return None

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -1,0 +1,231 @@
+"""
+Async email service for DailyNotes.
+Uses SMTP with aiosmtplib for async email sending.
+"""
+
+import aiosmtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class EmailService:
+    """
+    Service for sending emails asynchronously via SMTP.
+
+    Supports password reset and magic link emails with HTML and plain text versions.
+    """
+
+    def __init__(self, app=None):
+        self.smtp_host = None
+        self.smtp_port = None
+        self.smtp_user = None
+        self.smtp_password = None
+        self.smtp_use_tls = True
+        self.from_email = None
+        self.from_name = "DailyNotes"
+        self.app_url = "http://localhost:8000"
+        self.enabled = False
+
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Initialize the email service with app configuration."""
+        self.smtp_host = app.config.get("SMTP_HOST")
+        self.smtp_port = app.config.get("SMTP_PORT", 587)
+        self.smtp_user = app.config.get("SMTP_USER")
+        self.smtp_password = app.config.get("SMTP_PASSWORD")
+        self.smtp_use_tls = app.config.get("SMTP_USE_TLS", True)
+        self.from_email = app.config.get("SMTP_FROM_EMAIL") or self.smtp_user
+        self.from_name = app.config.get("SMTP_FROM_NAME", "DailyNotes")
+        self.app_url = app.config.get("APP_URL", "http://localhost:8000")
+        self.enabled = bool(self.smtp_host and self.smtp_user and self.smtp_password)
+
+        if self.enabled:
+            logger.info(
+                f"Email service configured: host={self.smtp_host}, port={self.smtp_port}, "
+                f"user={self.smtp_user}, from={self.from_email}, tls={self.smtp_use_tls}"
+            )
+        else:
+            logger.warning(
+                "Email service not configured. "
+                "Set SMTP_HOST, SMTP_USER, and SMTP_PASSWORD to enable email features."
+            )
+
+    @property
+    def is_enabled(self):
+        """Check if email service is properly configured."""
+        return self.enabled
+
+    async def send_email(
+        self,
+        to_email: str,
+        subject: str,
+        html_body: str,
+        text_body: Optional[str] = None,
+    ) -> bool:
+        """
+        Send an email asynchronously.
+
+        Args:
+            to_email: Recipient email address
+            subject: Email subject line
+            html_body: HTML content of the email
+            text_body: Plain text fallback (optional)
+
+        Returns:
+            True if email was sent successfully, False otherwise
+        """
+        if not self.enabled:
+            logger.warning("Email service not configured, skipping email send")
+            return False
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = f"{self.from_name} <{self.from_email}>"
+        msg["To"] = to_email
+
+        if text_body:
+            msg.attach(MIMEText(text_body, "plain"))
+        msg.attach(MIMEText(html_body, "html"))
+
+        logger.info(f"Sending email to {to_email}: {subject}")
+
+        try:
+            await aiosmtplib.send(
+                msg,
+                hostname=self.smtp_host,
+                port=self.smtp_port,
+                username=self.smtp_user,
+                password=self.smtp_password,
+                start_tls=self.smtp_use_tls,
+            )
+            logger.info(f"Email sent successfully to {to_email}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to send email to {to_email}: {e}")
+            return False
+
+    async def send_password_reset(self, to_email: str, token: str) -> bool:
+        """
+        Send password reset email.
+
+        Args:
+            to_email: Recipient email address
+            token: Password reset token
+
+        Returns:
+            True if email was sent successfully
+        """
+        reset_url = f"{self.app_url}/auth/reset-password?token={token}"
+
+        subject = "Reset Your DailyNotes Password"
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; padding: 40px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <h1 style="color: #333; margin-top: 0; margin-bottom: 24px;">Reset Your Password</h1>
+        <p style="color: #555; line-height: 1.6; margin-bottom: 24px;">
+            You requested to reset your DailyNotes password. Click the button below to set a new password:
+        </p>
+        <p style="margin: 32px 0; text-align: center;">
+            <a href="{reset_url}" style="background-color: #48c774; color: #ffffff; padding: 14px 32px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 600; font-size: 16px;">
+                Reset Password
+            </a>
+        </p>
+        <p style="color: #888; font-size: 14px; line-height: 1.5; margin-bottom: 8px;">
+            This link will expire in <strong>1 hour</strong>.
+        </p>
+        <p style="color: #888; font-size: 14px; line-height: 1.5;">
+            If you didn't request this, you can safely ignore this email. Your password will remain unchanged.
+        </p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;">
+        <p style="color: #aaa; font-size: 12px; line-height: 1.5; margin-bottom: 0;">
+            If the button doesn't work, copy and paste this URL into your browser:<br>
+            <a href="{reset_url}" style="color: #48c774; word-break: break-all;">{reset_url}</a>
+        </p>
+    </div>
+</body>
+</html>
+"""
+        text_body = f"""Reset Your Password
+
+You requested to reset your DailyNotes password.
+Visit this link to set a new password: {reset_url}
+
+This link will expire in 1 hour.
+
+If you didn't request this, you can safely ignore this email.
+Your password will remain unchanged.
+"""
+        return await self.send_email(to_email, subject, html_body, text_body)
+
+    async def send_magic_link(self, to_email: str, token: str) -> bool:
+        """
+        Send magic link login email.
+
+        Args:
+            to_email: Recipient email address
+            token: Magic link token
+
+        Returns:
+            True if email was sent successfully
+        """
+        login_url = f"{self.app_url}/auth/verify-magic-link?token={token}"
+
+        subject = "Sign in to DailyNotes"
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; padding: 40px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <h1 style="color: #333; margin-top: 0; margin-bottom: 24px;">Sign in to DailyNotes</h1>
+        <p style="color: #555; line-height: 1.6; margin-bottom: 24px;">
+            Click the button below to sign in to your account:
+        </p>
+        <p style="margin: 32px 0; text-align: center;">
+            <a href="{login_url}" style="background-color: #3273dc; color: #ffffff; padding: 14px 32px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 600; font-size: 16px;">
+                Sign In
+            </a>
+        </p>
+        <p style="color: #888; font-size: 14px; line-height: 1.5; margin-bottom: 8px;">
+            This link will expire in <strong>15 minutes</strong>.
+        </p>
+        <p style="color: #888; font-size: 14px; line-height: 1.5;">
+            If you didn't request this, you can safely ignore this email.
+        </p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;">
+        <p style="color: #aaa; font-size: 12px; line-height: 1.5; margin-bottom: 0;">
+            If the button doesn't work, copy and paste this URL into your browser:<br>
+            <a href="{login_url}" style="color: #3273dc; word-break: break-all;">{login_url}</a>
+        </p>
+    </div>
+</body>
+</html>
+"""
+        text_body = f"""Sign in to DailyNotes
+
+Click this link to sign in to your account: {login_url}
+
+This link will expire in 15 minutes.
+
+If you didn't request this, you can safely ignore this email.
+"""
+        return await self.send_email(to_email, subject, html_body, text_body)
+
+
+# Global email service instance - initialized with app in __init__.py
+email_service = EmailService()

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -18,6 +18,14 @@ const HomeRedirect = () => import(/* webpackChunkName: "home" */ '../views/HomeR
 const Auth = () => import(/* webpackChunkName: "auth" */ '../views/Auth.vue');
 const Login = () => import(/* webpackChunkName: "auth" */ '../views/Login.vue');
 const Signup = () => import(/* webpackChunkName: "auth" */ '../views/Signup.vue');
+const ForgotPassword = () =>
+  import(/* webpackChunkName: "auth" */ '../views/ForgotPassword.vue');
+const ResetPassword = () =>
+  import(/* webpackChunkName: "auth" */ '../views/ResetPassword.vue');
+const MagicLinkRequest = () =>
+  import(/* webpackChunkName: "auth" */ '../views/MagicLinkRequest.vue');
+const MagicLinkVerify = () =>
+  import(/* webpackChunkName: "auth" */ '../views/MagicLinkVerify.vue');
 
 const routes: RouteRecordRaw[] = [
   {
@@ -35,6 +43,26 @@ const routes: RouteRecordRaw[] = [
         path: 'sign-up',
         name: 'Sign Up',
         component: Signup,
+      },
+      {
+        path: 'forgot-password',
+        name: 'Forgot Password',
+        component: ForgotPassword,
+      },
+      {
+        path: 'reset-password',
+        name: 'Reset Password',
+        component: ResetPassword,
+      },
+      {
+        path: 'magic-link',
+        name: 'Magic Link',
+        component: MagicLinkRequest,
+      },
+      {
+        path: 'verify-magic-link',
+        name: 'Verify Magic Link',
+        component: MagicLinkVerify,
       },
     ],
   },

--- a/client/src/views/Day.vue
+++ b/client/src/views/Day.vue
@@ -41,7 +41,7 @@ import {
   watch,
 } from 'vue';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
-import type Editor from '@/components/Editor.vue';
+import Editor from '@/components/Editor.vue';
 import Header from '@/components/Header.vue';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import UnsavedForm from '@/components/UnsavedForm.vue';

--- a/client/src/views/ForgotPassword.vue
+++ b/client/src/views/ForgotPassword.vue
@@ -1,0 +1,133 @@
+<template>
+  <div>
+    <div class="msgs">{{ errMsg }}</div>
+    <div class="inputs" v-if="!submitted">
+      <p class="info-text">Enter your email address and we'll send you a link to reset your password.</p>
+      <b-field :type="emailErr ? 'is-danger' : ''" :message="emailErr">
+        <b-input
+          placeholder="Email"
+          type="email"
+          size="is-medium"
+          icon="envelope"
+          v-model="email"
+          @keyup.enter="submit"
+        ></b-input>
+      </b-field>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="submit"
+        :loading="isLoading"
+      >
+        Send Reset Link
+      </b-button>
+      <h1 class="mt-20 alt-button" @click="goToLogin">Back to Login</h1>
+    </div>
+    <div class="inputs" v-else>
+      <div class="success-message">
+        <b-icon icon="check-circle" type="is-success" size="is-large"></b-icon>
+        <p class="success-text">
+          If an account exists with that email, you'll receive a password reset link shortly.
+        </p>
+      </div>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="goToLogin"
+      >
+        Back to Login
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead } from '@unhead/vue';
+import { getCurrentInstance, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { Requests } from '../services/requests';
+
+useHead({
+  title: 'Forgot Password',
+});
+
+const router = useRouter();
+const instance = getCurrentInstance();
+const buefy = (instance?.appContext.config.globalProperties as any).$buefy;
+
+const email = ref('');
+const emailErr = ref('');
+const errMsg = ref('');
+const isLoading = ref(false);
+const submitted = ref(false);
+
+const goToLogin = () => {
+  router.push({ name: 'Login' });
+};
+
+const submit = async () => {
+  if (isLoading.value) {
+    return;
+  }
+
+  emailErr.value = '';
+  errMsg.value = '';
+
+  if (!email.value || !email.value.length) {
+    emailErr.value = 'Email is required';
+    return;
+  }
+
+  if (!email.value.includes('@')) {
+    emailErr.value = 'Please enter a valid email address';
+    return;
+  }
+
+  isLoading.value = true;
+
+  try {
+    await Requests.post('/forgot-password', {
+      email: email.value,
+    });
+    submitted.value = true;
+  } catch (e: any) {
+    if (e.response?.status === 429) {
+      errMsg.value = 'Too many requests. Please try again later.';
+    } else {
+      errMsg.value = 'There was an error. Please try again.';
+    }
+    buefy?.toast.open({
+      duration: 5000,
+      message: errMsg.value,
+      position: 'is-top',
+      type: 'is-danger',
+    });
+  }
+
+  isLoading.value = false;
+};
+</script>
+
+<style scoped>
+.info-text {
+  color: var(--text-secondary, #666);
+  margin-bottom: 20px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.success-message {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.success-text {
+  color: var(--text-secondary, #666);
+  margin-top: 15px;
+  font-size: 14px;
+}
+</style>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,14 +1,42 @@
 <template>
   <div>
-    <div class="msgs">{{errMsg}}</div>
+    <div class="msgs">{{ errMsg }}</div>
     <div class="inputs">
       <b-field :type="usernameErr ? 'is-danger' : ''" :message="usernameErr">
-        <b-input placeholder="Username" size="is-medium" icon="user" v-model="username" @keyup.enter="login"></b-input>
+        <b-input
+          placeholder="Username"
+          size="is-medium"
+          icon="user"
+          v-model="username"
+          @keyup.enter="login"
+        ></b-input>
       </b-field>
       <b-field :type="passwordErr ? 'is-danger' : ''" :message="passwordErr">
-        <b-input placeholder="Password" type="password" password-reveal size="is-medium" icon="key" v-model="password" @keyup.enter="login"></b-input>
+        <b-input
+          placeholder="Password"
+          type="password"
+          password-reveal
+          size="is-medium"
+          icon="key"
+          v-model="password"
+          @keyup.enter="login"
+        ></b-input>
       </b-field>
-      <b-button type="is-primary" size="is-medium" expanded class="mt-20" @click="login" :loading="isLoading">Login</b-button>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="login"
+        :loading="isLoading"
+      >
+        Login
+      </b-button>
+      <div class="auth-links mt-20">
+        <span class="alt-button" @click="forgotPassword">Forgot password?</span>
+        <span class="separator">|</span>
+        <span class="alt-button" @click="magicLink">Sign in with email</span>
+      </div>
       <h1 class="mt-20 alt-button" @click="signup" v-if="!hideSignup">Sign Up</h1>
     </div>
   </div>
@@ -40,6 +68,14 @@ const hideSignup = !!process.env.VUE_APP_PREVENT_SIGNUPS;
 
 const signup = () => {
   router.push({ name: 'Sign Up' });
+};
+
+const forgotPassword = () => {
+  router.push({ name: 'Forgot Password' });
+};
+
+const magicLink = () => {
+  router.push({ name: 'Magic Link' });
 };
 
 const login = async () => {
@@ -94,3 +130,15 @@ const login = async () => {
   isLoading.value = false;
 };
 </script>
+
+<style scoped>
+.auth-links {
+  text-align: center;
+  font-size: 14px;
+}
+
+.auth-links .separator {
+  margin: 0 10px;
+  color: var(--text-muted, #999);
+}
+</style>

--- a/client/src/views/MagicLinkRequest.vue
+++ b/client/src/views/MagicLinkRequest.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <div class="msgs">{{ errMsg }}</div>
+    <div class="inputs" v-if="!submitted">
+      <p class="info-text">Enter your email address and we'll send you a magic link to sign in.</p>
+      <b-field :type="emailErr ? 'is-danger' : ''" :message="emailErr">
+        <b-input
+          placeholder="Email"
+          type="email"
+          size="is-medium"
+          icon="envelope"
+          v-model="email"
+          @keyup.enter="submit"
+        ></b-input>
+      </b-field>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="submit"
+        :loading="isLoading"
+      >
+        Send Magic Link
+      </b-button>
+      <h1 class="mt-20 alt-button" @click="goToLogin">Back to Login</h1>
+    </div>
+    <div class="inputs" v-else>
+      <div class="success-message">
+        <b-icon icon="check-circle" type="is-success" size="is-large"></b-icon>
+        <p class="success-text">
+          Check your email! If an account exists, you'll receive a sign-in link shortly.
+        </p>
+        <p class="warning-text">The link expires in 15 minutes.</p>
+      </div>
+      <b-button type="is-light" size="is-medium" expanded class="mt-20" @click="goToLogin">
+        Back to Login
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead } from '@unhead/vue';
+import { getCurrentInstance, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { Requests } from '../services/requests';
+
+useHead({
+  title: 'Sign in with Email',
+});
+
+const router = useRouter();
+const instance = getCurrentInstance();
+const buefy = (instance?.appContext.config.globalProperties as any).$buefy;
+
+const email = ref('');
+const emailErr = ref('');
+const errMsg = ref('');
+const isLoading = ref(false);
+const submitted = ref(false);
+
+const goToLogin = () => {
+  router.push({ name: 'Login' });
+};
+
+const submit = async () => {
+  if (isLoading.value) {
+    return;
+  }
+
+  emailErr.value = '';
+  errMsg.value = '';
+
+  if (!email.value || !email.value.length) {
+    emailErr.value = 'Email is required';
+    return;
+  }
+
+  if (!email.value.includes('@')) {
+    emailErr.value = 'Please enter a valid email address';
+    return;
+  }
+
+  isLoading.value = true;
+
+  try {
+    await Requests.post('/magic-link', {
+      email: email.value,
+    });
+    submitted.value = true;
+  } catch (e: any) {
+    if (e.response?.status === 429) {
+      errMsg.value = 'Too many requests. Please try again later.';
+    } else {
+      errMsg.value = 'There was an error. Please try again.';
+    }
+    buefy?.toast.open({
+      duration: 5000,
+      message: errMsg.value,
+      position: 'is-top',
+      type: 'is-danger',
+    });
+  }
+
+  isLoading.value = false;
+};
+</script>
+
+<style scoped>
+.info-text {
+  color: var(--text-secondary, #666);
+  margin-bottom: 20px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.success-message {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.success-text {
+  color: var(--text-secondary, #666);
+  margin-top: 15px;
+  font-size: 14px;
+}
+
+.warning-text {
+  color: var(--text-muted, #999);
+  margin-top: 10px;
+  font-size: 12px;
+}
+</style>

--- a/client/src/views/MagicLinkVerify.vue
+++ b/client/src/views/MagicLinkVerify.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <div class="inputs">
+      <div v-if="isLoading" class="verifying">
+        <b-loading :is-full-page="false" :active="true"></b-loading>
+        <p class="loading-text">Verifying your magic link...</p>
+      </div>
+      <div v-else-if="error" class="error-state">
+        <b-icon icon="exclamation-circle" type="is-danger" size="is-large"></b-icon>
+        <p class="error-text">{{ error }}</p>
+        <b-button
+          type="is-primary"
+          size="is-medium"
+          expanded
+          class="mt-20"
+          @click="goToMagicLink"
+        >
+          Request New Link
+        </b-button>
+        <h1 class="mt-20 alt-button" @click="goToLogin">Back to Login</h1>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead } from '@unhead/vue';
+import { getCurrentInstance, ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { Requests } from '../services/requests';
+import { setToken } from '../services/user';
+
+useHead({
+  title: 'Signing In...',
+});
+
+const router = useRouter();
+const route = useRoute();
+const instance = getCurrentInstance();
+const buefy = (instance?.appContext.config.globalProperties as any).$buefy;
+
+const isLoading = ref(true);
+const error = ref('');
+
+const goToLogin = () => {
+  router.push({ name: 'Login' });
+};
+
+const goToMagicLink = () => {
+  router.push({ name: 'Magic Link' });
+};
+
+onMounted(async () => {
+  const token = (route.query.token as string) || '';
+
+  if (!token) {
+    error.value = 'No token provided';
+    isLoading.value = false;
+    return;
+  }
+
+  try {
+    const res = await Requests.post('/magic-link/verify', { token });
+    if (res.data?.access_token) {
+      setToken(res.data.access_token);
+      buefy?.toast.open({
+        duration: 3000,
+        message: 'Successfully signed in!',
+        position: 'is-top',
+        type: 'is-success',
+      });
+      router.push({ name: 'Home Redirect' });
+    } else {
+      throw new Error('Invalid response');
+    }
+  } catch (e: any) {
+    if (e.response?.data?.error) {
+      error.value = e.response.data.error;
+    } else {
+      error.value = 'This link is invalid or has expired.';
+    }
+  }
+
+  isLoading.value = false;
+});
+</script>
+
+<style scoped>
+.verifying {
+  text-align: center;
+  padding: 40px 0;
+  position: relative;
+  min-height: 100px;
+}
+
+.loading-text {
+  color: var(--text-secondary, #666);
+  margin-top: 60px;
+  font-size: 14px;
+}
+
+.error-state {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.error-text {
+  color: var(--text-secondary, #666);
+  margin-top: 15px;
+  font-size: 14px;
+}
+</style>

--- a/client/src/views/Note.vue
+++ b/client/src/views/Note.vue
@@ -37,7 +37,7 @@ import {
   ref,
 } from 'vue';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
-import type Editor from '@/components/Editor.vue';
+import Editor from '@/components/Editor.vue';
 import Header from '@/components/Header.vue';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import type { IHeaderOptions, INote } from '../interfaces';

--- a/client/src/views/ResetPassword.vue
+++ b/client/src/views/ResetPassword.vue
@@ -1,0 +1,171 @@
+<template>
+  <div>
+    <div class="msgs">{{ errMsg }}</div>
+    <div class="inputs" v-if="!success">
+      <p class="info-text">Enter your new password below.</p>
+      <b-field :type="passwordErr ? 'is-danger' : ''" :message="passwordErr">
+        <b-input
+          placeholder="New Password"
+          type="password"
+          password-reveal
+          size="is-medium"
+          icon="key"
+          v-model="password"
+          @keyup.enter="submit"
+        ></b-input>
+      </b-field>
+      <b-field :type="confirmErr ? 'is-danger' : ''" :message="confirmErr">
+        <b-input
+          placeholder="Confirm Password"
+          type="password"
+          password-reveal
+          size="is-medium"
+          icon="key"
+          v-model="confirmPassword"
+          @keyup.enter="submit"
+        ></b-input>
+      </b-field>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="submit"
+        :loading="isLoading"
+      >
+        Reset Password
+      </b-button>
+    </div>
+    <div class="inputs" v-else>
+      <div class="success-message">
+        <b-icon icon="check-circle" type="is-success" size="is-large"></b-icon>
+        <p class="success-text">Your password has been reset successfully!</p>
+      </div>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="goToLogin"
+      >
+        Continue to Login
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead } from '@unhead/vue';
+import { getCurrentInstance, ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { Requests } from '../services/requests';
+
+useHead({
+  title: 'Reset Password',
+});
+
+const router = useRouter();
+const route = useRoute();
+const instance = getCurrentInstance();
+const buefy = (instance?.appContext.config.globalProperties as any).$buefy;
+
+const password = ref('');
+const passwordErr = ref('');
+const confirmPassword = ref('');
+const confirmErr = ref('');
+const errMsg = ref('');
+const isLoading = ref(false);
+const success = ref(false);
+const token = ref('');
+
+onMounted(() => {
+  token.value = (route.query.token as string) || '';
+  if (!token.value) {
+    errMsg.value = 'Invalid or missing reset token';
+  }
+});
+
+const goToLogin = () => {
+  router.push({ name: 'Login' });
+};
+
+const submit = async () => {
+  if (isLoading.value) {
+    return;
+  }
+
+  passwordErr.value = '';
+  confirmErr.value = '';
+  errMsg.value = '';
+
+  if (!password.value || !password.value.length) {
+    passwordErr.value = 'Password is required';
+    return;
+  }
+
+  if (password.value.length < 4) {
+    passwordErr.value = 'Password must be at least 4 characters';
+    return;
+  }
+
+  if (password.value !== confirmPassword.value) {
+    confirmErr.value = 'Passwords do not match';
+    return;
+  }
+
+  if (!token.value) {
+    errMsg.value = 'Invalid or missing reset token';
+    return;
+  }
+
+  isLoading.value = true;
+
+  try {
+    await Requests.post('/reset-password', {
+      token: token.value,
+      password: password.value,
+    });
+    success.value = true;
+    buefy?.toast.open({
+      duration: 5000,
+      message: 'Password reset successfully!',
+      position: 'is-top',
+      type: 'is-success',
+    });
+  } catch (e: any) {
+    if (e.response?.data?.error) {
+      errMsg.value = e.response.data.error;
+    } else {
+      errMsg.value = 'Invalid or expired reset link. Please request a new one.';
+    }
+    buefy?.toast.open({
+      duration: 5000,
+      message: errMsg.value,
+      position: 'is-top',
+      type: 'is-danger',
+    });
+  }
+
+  isLoading.value = false;
+};
+</script>
+
+<style scoped>
+.info-text {
+  color: var(--text-secondary, #666);
+  margin-bottom: 20px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.success-message {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.success-text {
+  color: var(--text-secondary, #666);
+  margin-top: 15px;
+  font-size: 14px;
+}
+</style>

--- a/client/src/views/Signup.vue
+++ b/client/src/views/Signup.vue
@@ -1,17 +1,59 @@
 <template>
   <div>
-    <div class="msgs">{{errMsg}}</div>
+    <div class="msgs">{{ errMsg }}</div>
     <div class="inputs">
       <b-field :type="usernameErr ? 'is-danger' : ''" :message="usernameErr">
-        <b-input placeholder="Username" size="is-medium" icon="user" v-model="username" @keyup.enter="signup"></b-input>
+        <b-input
+          placeholder="Username"
+          size="is-medium"
+          icon="user"
+          v-model="username"
+          @keyup.enter="signup"
+        ></b-input>
       </b-field>
+      <b-field :type="emailErr ? 'is-danger' : ''" :message="emailErr">
+        <b-input
+          placeholder="Email (optional)"
+          type="email"
+          size="is-medium"
+          icon="envelope"
+          v-model="email"
+          @keyup.enter="signup"
+        ></b-input>
+      </b-field>
+      <p class="email-hint">Add email to enable password recovery and magic link sign-in</p>
       <b-field :type="passwordErr ? 'is-danger' : ''" :message="passwordErr">
-        <b-input placeholder="Password" type="password" password-reveal size="is-medium" icon="key" v-model="password" @keyup.enter="signup"></b-input>
+        <b-input
+          placeholder="Password"
+          type="password"
+          password-reveal
+          size="is-medium"
+          icon="key"
+          v-model="password"
+          @keyup.enter="signup"
+        ></b-input>
       </b-field>
       <b-field :type="passConfirmErr ? 'is-danger' : ''" :message="passConfirmErr">
-        <b-input placeholder="Confirm Password" type="password" password-reveal size="is-medium" icon="key" v-model="passwordConfirm" @keyup.enter="signup"></b-input>
+        <b-input
+          placeholder="Confirm Password"
+          type="password"
+          password-reveal
+          size="is-medium"
+          icon="key"
+          v-model="passwordConfirm"
+          @keyup.enter="signup"
+        ></b-input>
       </b-field>
-      <b-button type="is-primary" size="is-medium" expanded class="mt-20" @click="signup" :loading="isLoading">Sign Up</b-button>
+      <b-button
+        type="is-primary"
+        size="is-medium"
+        expanded
+        class="mt-20"
+        @click="signup"
+        :loading="isLoading"
+      >
+        Sign Up
+      </b-button>
       <h1 class="mt-20 alt-button" @click="login">Login</h1>
     </div>
   </div>
@@ -35,6 +77,8 @@ const buefy = (instance?.appContext.config.globalProperties as any).$buefy;
 
 const username = ref('');
 const usernameErr = ref('');
+const email = ref('');
+const emailErr = ref('');
 const password = ref('');
 const passwordErr = ref('');
 const passwordConfirm = ref('');
@@ -59,6 +103,7 @@ const signup = async () => {
   }
 
   usernameErr.value = '';
+  emailErr.value = '';
   passwordErr.value = '';
   passConfirmErr.value = '';
   errMsg.value = '';
@@ -66,6 +111,14 @@ const signup = async () => {
   if (!username.value || !username.value.length) {
     usernameErr.value = 'Username must be filled';
     return;
+  }
+
+  // Validate email format if provided
+  if (email.value && email.value.length > 0) {
+    if (!email.value.includes('@') || !email.value.includes('.')) {
+      emailErr.value = 'Please enter a valid email address';
+      return;
+    }
   }
 
   if (!password.value || !password.value.length) {
@@ -81,10 +134,17 @@ const signup = async () => {
   isLoading.value = true;
 
   try {
-    const res = await Requests.post('/sign-up', {
+    const payload: { username: string; password: string; email?: string } = {
       username: username.value,
       password: password.value,
-    });
+    };
+
+    // Only include email if provided
+    if (email.value && email.value.trim().length > 0) {
+      payload.email = email.value.trim();
+    }
+
+    const res = await Requests.post('/sign-up', payload);
     if (res.data?.access_token) {
       setToken(res.data.access_token);
 
@@ -111,3 +171,12 @@ const signup = async () => {
   isLoading.value = false;
 };
 </script>
+
+<style scoped>
+.email-hint {
+  color: var(--text-muted, #999);
+  font-size: 12px;
+  margin: -8px 0 12px 0;
+  text-align: center;
+}
+</style>

--- a/config.py
+++ b/config.py
@@ -20,3 +20,15 @@ class Config(object):
     )  # 10MB default
     ALLOWED_UPLOAD_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
     DEFAULT_TIMEZONE = os.environ.get("DEFAULT_TIMEZONE", None)
+
+    # SMTP Configuration for password reset and magic link emails
+    SMTP_HOST = os.environ.get("SMTP_HOST")
+    SMTP_PORT = int(os.environ.get("SMTP_PORT", 587))
+    SMTP_USER = os.environ.get("SMTP_USER")
+    SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD")
+    SMTP_USE_TLS = os.environ.get("SMTP_USE_TLS", "true").lower() == "true"
+    SMTP_FROM_EMAIL = os.environ.get("SMTP_FROM_EMAIL")
+    SMTP_FROM_NAME = os.environ.get("SMTP_FROM_NAME", "DailyNotes")
+
+    # Application URL for email links (e.g., password reset, magic link)
+    APP_URL = os.environ.get("APP_URL", "http://localhost:8000")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,12 +34,10 @@ services:
       - /app/client/node_modules
       - /app/__pycache__
       - /app/app/__pycache__
+    env_file:
+      - ./.env
     environment:
-      # These will be generated automatically if not provided
-      # Uncomment and set for production-like development
-      # API_SECRET_KEY: "dev-secret-key-change-in-production"
-      # DB_ENCRYPTION_KEY: "dev-encryption-key-must-be-multiple-of-16-chars"
-
+      # These override values from .env if needed
       # Development mode flags
       NODE_ENV: development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,15 @@ services:
     environment:
       API_SECRET_KEY: CHANGE_THIS_WITH_SECURE_PASSWORD
       DB_ENCRYPTION_KEY: CHANGE_THIS_WITH_SECURE_PASSWORD
+      # Optional: SMTP settings for password reset & magic link sign-in
+      # SMTP_HOST: smtp.example.com
+      # SMTP_PORT: 587
+      # SMTP_USER: your-smtp-username
+      # SMTP_PASSWORD: your-smtp-password
+      # SMTP_USE_TLS: "true"
+      # SMTP_FROM_EMAIL: noreply@example.com
+      # SMTP_FROM_NAME: DailyNotes
+      # APP_URL: https://your-domain.com
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/migrations/versions/email_and_auth_tokens.py
+++ b/migrations/versions/email_and_auth_tokens.py
@@ -1,0 +1,63 @@
+"""Add email to user and auth_token/rate_limit tables
+
+Revision ID: email_auth_tokens_001
+Revises: week_start_monday_001
+Create Date: 2025-12-16 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from app.model_types import GUID
+
+
+# revision identifiers, used by Alembic.
+revision = "email_auth_tokens_001"
+down_revision = "week_start_monday_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add email column to user table
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("email", sa.LargeBinary(), nullable=True))
+
+    # Create auth_token table
+    op.create_table(
+        "auth_token",
+        sa.Column("uuid", GUID(), nullable=False),
+        sa.Column("user_id", GUID(), nullable=False),
+        sa.Column("token_hash", sa.String(128), nullable=False),
+        sa.Column("token_type", sa.String(32), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("uuid"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.uuid"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_auth_token_uuid", "auth_token", ["uuid"], unique=True)
+    op.create_index("ix_auth_token_token_hash", "auth_token", ["token_hash"])
+
+    # Create rate_limit table
+    op.create_table(
+        "rate_limit",
+        sa.Column("uuid", GUID(), nullable=False),
+        sa.Column("identifier", sa.String(256), nullable=False),
+        sa.Column("action_type", sa.String(32), nullable=False),
+        sa.Column(
+            "timestamp", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.PrimaryKeyConstraint("uuid"),
+    )
+    op.create_index("ix_rate_limit_uuid", "rate_limit", ["uuid"], unique=True)
+    op.create_index("ix_rate_limit_identifier", "rate_limit", ["identifier"])
+
+
+def downgrade():
+    op.drop_table("rate_limit")
+    op.drop_table("auth_token")
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_column("email")

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pycryptodome==3.23.0
 httpx==0.28.1  # Async HTTP client (replaces requests for async operations)
 requests==2.32.5  # Keep for sync operations if needed
 python-dateutil==2.9.0.post0
+aiosmtplib==3.0.1  # Async SMTP for email sending
 
 # Development
 black==25.12.0


### PR DESCRIPTION
Add email-based authentication features:
- Forgot password flow with secure reset tokens
- Magic link passwordless sign-in
- Optional email field on signup and in Settings
- Rate limiting (3 requests/email/hour)
- Email enumeration prevention

Security measures:
- Tokens hashed with SHA-256 before storage
- Password reset tokens expire in 1 hour
- Magic link tokens expire in 15 minutes
- User emails encrypted at rest with AES

New files:
- app/email_service.py - Async SMTP with aiosmtplib
- app/auth_tokens.py - Token generation and validation
- 4 new Vue auth components

Also fixes Editor component import in Day.vue and Note.vue (was type-only import causing runtime errors)