### PR TITLE
fix: rollback db session on exception to prevent cascade errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,6 +60,9 @@ db = DatabaseWrapper(engine, db_session, Base)
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     """Remove the database session at the end of each request."""
+    if exception:
+        # Rollback the session if there was an exception to clear the failed state
+        db_session.rollback()
     db_session.remove()
 
 


### PR DESCRIPTION
When a request failed with an exception, the session was left in a "needs rollback" state. Subsequent requests would fail with PendingRollbackError because db_session.remove() doesn't clear the failed transaction state.

- Add db_session.rollback() in teardown when exception occurs
- Add explicit error handling in SSE endpoint with logging